### PR TITLE
added system-alloc feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -147,8 +147,10 @@ bindgen = "0.69"
 cc = "1"
 
 [features]
-default = ["min-redis-compatibility-version-6-0"]
+default = ["min-redis-compatibility-version-7-0"]
 min-redis-compatibility-version-7-2 = []
 min-redis-compatibility-version-7-0 = []
 min-redis-compatibility-version-6-2 = []
 min-redis-compatibility-version-6-0 = []
+# this is used to enable System.alloc instead of ValkeyAlloc for tests
+enable-system-alloc = []

--- a/README.md
+++ b/README.md
@@ -25,5 +25,19 @@ This repo was forked from [redismodule-rs](https://github.com/RedisLabsModules/r
 
 See the [examples](examples) directory for some sample modules.
 
+To optionally enter the `System.alloc` code paths in `alloc.rs` specify this in `Cargo.toml` of your module:
+```
+[features]
+enable-system-alloc = ["valkey-module/system-alloc"]
+```
+For unit tests with `System.alloc` use this: 
+```
+cargo test --features enable-system-alloc
+```
+For integration tests with `ValkeyAlloc` use this:
+```
+cargo test
+```
+
 This crate tries to provide high-level wrappers around the standard Valkey Modules API, while preserving the API's basic concepts.
 Therefore, following the [Valkeyi Modules API](https://valkey.io/topics/modules-api-ref/) documentation will be mostly relevant here as well.


### PR DESCRIPTION
when trying to create unit tests for Valkey modules using Rust SDK we keep getting error: `Critical error: the Valkey Allocator isn't available.`

This allows to specify feature `global-alloc` in module Cargo.toml to use `System.alloc` in module unit tests.  

```
[dependencies]
...
valkey-module ...

[features]
enable-system-alloc = ["valkey-module/system-alloc"


```

